### PR TITLE
FEATURE: Privacy + notification settings

### DIFF
--- a/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
@@ -1,8 +1,10 @@
 {{#if siteSettings.discourse_follow_enabled}}
-  {{#if user.total_following}}
-    {{follow-statistic label="user.following.label" total=user.total_following context="card"}}
-  {{/if}}
-  {{#if user.total_followers}}
-    {{follow-statistic label="user.followers.label" total=user.total_followers context="card"}}
+  {{#if siteSettings.follow_show_statistics_on_profile}}
+    {{#if user.total_following}}
+      {{follow-statistic label="user.following.label" total=user.total_following context="card"}}
+    {{/if}}
+    {{#if user.total_followers}}
+      {{follow-statistic label="user.followers.label" total=user.total_followers context="card"}}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/connectors/user-main-nav/follow-user-container.hbs
+++ b/assets/javascripts/discourse/connectors/user-main-nav/follow-user-container.hbs
@@ -1,3 +1,5 @@
 {{#if siteSettings.discourse_follow_enabled}}
-  {{#link-to 'follow'}}{{d-icon "users"}}{{i18n 'user.follow_nav'}}{{/link-to}}
+  {{#if model.can_see_follow}}
+    {{#link-to 'follow'}}{{d-icon "users"}}{{i18n 'user.follow_nav'}}{{/link-to}}
+  {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/connectors/user-preferences-notifications/follow-notification-settings.hbs
+++ b/assets/javascripts/discourse/connectors/user-preferences-notifications/follow-notification-settings.hbs
@@ -1,0 +1,19 @@
+{{#if siteSettings.discourse_follow_enabled}}
+    {{#if siteSettings.follow_follower_notifications_enabled}}
+        <div class="control-group follow-notifications">
+            <label class="control-label">{{i18n 'user.followers.label'}}</label>
+
+            <div class="controls">
+
+                {{preference-checkbox
+                    labelKey="user.follower_disable_receive"
+                    checked=model.custom_fields.follower_disable_receive}}
+
+                {{preference-checkbox
+                    labelKey="user.follower_disable_send"
+                    checked=model.custom_fields.follower_disable_send}}
+                    
+            </div>
+        </div>
+    {{/if}}
+{{/if}}

--- a/assets/javascripts/discourse/connectors/user-profile-secondary/follow-statistics-user.hbs
+++ b/assets/javascripts/discourse/connectors/user-profile-secondary/follow-statistics-user.hbs
@@ -1,8 +1,10 @@
 {{#if siteSettings.discourse_follow_enabled}}
-  {{#if model.total_following}}
-    {{follow-statistic label="user.following.label" total=model.total_following context="profile"}}
-  {{/if}}
-  {{#if model.total_followers}}
-    {{follow-statistic label="user.followers.label" total=model.total_followers context="profile"}}
+  {{#if siteSettings.follow_show_statistics_on_profile}}
+    {{#if model.total_following}}
+      {{follow-statistic label="user.following.label" total=model.total_following context="profile"}}
+    {{/if}}
+    {{#if model.total_followers}}
+      {{follow-statistic label="user.followers.label" total=model.total_followers context="profile"}}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/initializers/follow-notification-settings.js.es6
+++ b/assets/javascripts/discourse/initializers/follow-notification-settings.js.es6
@@ -1,0 +1,21 @@
+import { withPluginApi } from "discourse/lib/plugin-api"
+
+export default {
+	name: "follow-notification-settings",
+
+	initialize() {
+		if(!Discourse.SiteSettings.discourse_follow_enabled)
+            return;
+
+		withPluginApi("0.8.24", api => {
+			api.modifyClass("controller:preferences/notifications", {
+				actions: {
+					save() {
+						this.get("saveAttrNames").push("custom_fields")
+						this._super()
+					}
+				}
+			})
+		})
+	}
+}

--- a/assets/javascripts/discourse/routes/follow.js.es6
+++ b/assets/javascripts/discourse/routes/follow.js.es6
@@ -1,6 +1,9 @@
 export default Discourse.Route.extend({
-  beforeModel() {
-    this.replaceWith('following');
+  afterModel(model) {
+    if (!model.can_see_follow)
+      this.transitionTo("user");
+    else if (model.can_see_following)
+      this.transitionTo("following");
   },
 
   actions:{

--- a/assets/javascripts/discourse/templates/follow.hbs
+++ b/assets/javascripts/discourse/templates/follow.hbs
@@ -1,11 +1,15 @@
 {{#d-section pageClass="user-follow" class="user-navigation" scrollTop="false"}}
   {{#mobile-nav class='activity-nav' desktopClass='action-list follow-list nav-stacked' currentPath=application.currentPath}}
-    <li>
-      {{#link-to 'following'}}{{i18n 'user.following.label'}}{{/link-to}}
-    </li>
-    <li>
-      {{#link-to 'followers'}}{{i18n 'user.followers.label'}}{{/link-to}}
-    </li>
+    {{#if model.can_see_following}}
+      <li>
+        {{#link-to 'following'}}{{i18n 'user.following.label'}}{{/link-to}}
+      </li>
+    {{/if}}
+    {{#if model.can_see_followers}}
+      <li>
+        {{#link-to 'followers'}}{{i18n 'user.followers.label'}}{{/link-to}}
+      </li>
+    {{/if}}
   {{/mobile-nav}}
 {{/d-section}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -27,6 +27,8 @@ en:
         label: "Following"
         none: "You're not following anyone yet."
         none_other: "{{username}} is not following anyone yet."
+      follower_disable_receive: "Disable being notified of new followers"
+      follower_disable_send: "Disable notifying users when you follow them"
       followers:
         label: "Followers"
         none: "No-one is following you yet."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,4 +1,5 @@
 en:
   site_settings:
     follow_show_statistics_on_profile: "Show follow statistics on user profiles."
+    follow_follower_notifications_enabled: "Enable new follower notifications."
     discourse_follow_enabled: "Enable follow plugin."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,8 @@
 en:
   site_settings:
+    follow_show_followers_on_profile: "Show a public list of followers on user profiles."
+    follow_show_followers_to_self: "Allow users to see their own list of followers."
+    follow_show_following_on_profile: "Show a public list of followed users on user profiles."
     follow_show_statistics_on_profile: "Show follow statistics on user profiles."
     follow_follower_notifications_enabled: "Enable new follower notifications."
     discourse_follow_enabled: "Enable follow plugin."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,10 @@
 plugins:
+  follow_show_followers_on_profile:
+    default: true
+  follow_show_followers_to_self:
+    default: true
+  follow_show_following_on_profile:
+    default: true
   follow_show_statistics_on_profile:
     default: true
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@ plugins:
   follow_show_statistics_on_profile:
     default: true
     client: true
+  follow_follower_notifications_enabled:
+    default: true
+    client: true
   discourse_follow_enabled:
     default: true
     client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -186,7 +186,8 @@ after_initialize do
       target.save_custom_fields(true)
       user.save_custom_fields(true)
 
-      if follow
+      if follow && SiteSetting.follow_follower_notifications_enabled
+        if !(user.custom_fields['follower_disable_send'] || target.custom_fields['follower_disable_receive'])
         target.notifications.create!(
           notification_type: Notification.types[:following],
           data: {
@@ -196,6 +197,7 @@ after_initialize do
         )
       end
     end
+  end
   end
 
   module PostAlerterFollowExtension
@@ -296,4 +298,15 @@ after_initialize do
   add_to_serializer(:user, :include_total_followers?) { SiteSetting.follow_show_statistics_on_profile }
   add_to_serializer(:user, :total_following) { object.following.length }
   add_to_serializer(:user, :include_total_following?) { SiteSetting.follow_show_statistics_on_profile }
+
+  User.register_custom_field_type("follower_disable_receive", :boolean)
+	DiscoursePluginRegistry.serialized_current_user_fields << "follower_disable_receive"
+	add_to_serializer(:current_user, :follower_disable_receive) { object.custom_fields["follower_disable_receive"] }
+  register_editable_user_custom_field :follower_disable_receive
+
+  User.register_custom_field_type("follower_disable_send", :boolean)
+  DiscoursePluginRegistry.serialized_current_user_fields << "follower_disable_send"
+  add_to_serializer(:current_user, :follower_disable_send) { object.custom_fields["follower_disable_send"] }
+  register_editable_user_custom_field :follower_disable_send
+  
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -326,8 +326,8 @@ after_initialize do
   }
 
   User.register_custom_field_type("follower_disable_receive", :boolean)
-	DiscoursePluginRegistry.serialized_current_user_fields << "follower_disable_receive"
-	add_to_serializer(:current_user, :follower_disable_receive) { object.custom_fields["follower_disable_receive"] }
+  DiscoursePluginRegistry.serialized_current_user_fields << "follower_disable_receive"
+  add_to_serializer(:current_user, :follower_disable_receive) { object.custom_fields["follower_disable_receive"] }
   register_editable_user_custom_field :follower_disable_receive
 
   User.register_custom_field_type("follower_disable_send", :boolean)


### PR DESCRIPTION
Hello! We run a 240,000+ user Discourse forum over at https://devforum.roblox.com/, and we needed some extra settings because we don't want to create a competitive environment w.r.t. follower/following counts (even if statistics are hidden), since we are dealing with a young community that is eager to game these kind of statistics.

Additionally, we want to avoid issues with "popular" users in our community being spammed by "new follower" notifications, so I added some settings here that prevent sending/receiving these notifications on a per-user basis, as well as a site-wide setting. The disabling of sending notifications can be used as a sort of "stealth mode" in case moderators want to follow users, but not let the users know that the moderator started following them.

I was wondering if you were interested in reviewing these changes and giving feedback on them / accepting them into upstream so others can benefit from them too.

### Overview of changes:
- Ability to stop receiving / sending notifications on new follower / following a person.
- Settings to hide part of Network from users:
   - Setting for only showing Following to user themselves, or everyone.
   - Setting for only showing Followers to no one, user themselves, or everyone.
   - The Network tab and inner Following/Follower tab will update depending on settings, i.e. if the user cannot view anything about the Network of the user they are viewing, the Network tab will not show.
- Bug fix for statistics showing up on profile while setting disabled.