### PR TITLE
FIX: Correct translation interpolation variables format

### DIFF
--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -18,18 +18,18 @@ ca:
         title: "Seguir"
         help: "temes amb publicacions d'usuaris que segueixes"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "t'ha començat a seguir."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       titles:
         following_posted: "nou tema d'algú que segueixes"
         following_replied: "nova publicació d'algú que segueixes"
         following: "algú t'ha començat a seguir"
       popup:
-        following: "{{username}} t'ha començat a seguir."
-        following_posted: '{{username}} ha publicat "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} ha publicat en "{{topic}}" - {{site_title}}'
+        following: "%{username} t'ha començat a seguir."
+        following_posted: '%{username} ha publicat "%{topic}" - %{site_title}'
+        following_replied: '%{username} ha publicat en "%{topic}" - %{site_title}'
     topics:
       none:
         following: "No hi ha temes d'usuaris que segueixes."
@@ -55,11 +55,11 @@ ca:
       following:
         label: "Seguint"
         none: "Encara no segueixes a ningú."
-        none_other: "{{username}} encara no segueix a ningú."
+        none_other: "%{username} encara no segueix a ningú."
       followers:
         label: "Seguidors"
         none: "Encara no et segueix ningú."
-        none_other: "Encara ningú segueix a {{username}}."
+        none_other: "Encara ningú segueix a %{username}."
       follow_notifications_options:
         notify_followed_user_when_followed: "Notifica als usuaris quan els segueixo."
         notify_me_when_followed: "Notifica'm quan els usuaris em segueixen."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,18 +1,18 @@
 en:
   js:
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "has started following you."
-      following_created_topic: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_created_topic: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       titles:
         following_created_topic: "new topic from someone you are following"
         following_replied: "new post from someone you are following"
         following: "someone has started following you"
       popup:
-        following: "{{username}} has started following you."
-        following_created_topic: '{{username}} created "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} posted in "{{topic}}" - {{site_title}}'
+        following: "%{username} has started following you."
+        following_created_topic: '%{username} created "%{topic}" - %{site_title}'
+        following_replied: '%{username} posted in "%{topic}" - %{site_title}'
     user:
       follow_nav: "Follows"
       follow:
@@ -21,15 +21,15 @@ en:
         feed_link: "Follow feed"
         label: "Following"
         none: "You're not following anyone yet."
-        none_other: "{{username}} is not following anyone yet."
+        none_other: "%{username} is not following anyone yet."
       followers:
         label: "Followers"
         none: "No-one is following you yet."
-        none_other: "No-one is following {{username}} yet."
+        none_other: "No-one is following %{username} yet."
       feed:
         label: "Feed"
         empty_feed_you: "No posts by people you follow yet."
-        empty_feed_other: "No posts by people {{username}} follows yet."
+        empty_feed_other: "No posts by people %{username} follows yet."
       follow_notifications_options:
         notify_followed_user_when_followed: "Notify users when I follow them"
         notify_me_when_followed: "Notify me when users follow me"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -18,18 +18,18 @@ es:
         title: "Siguiendo"
         help: "temas con publicaciones de usuarios que estás siguiendo"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "ha comenzado a seguirte."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       titles:
         following_posted: "nuevo tema de alguien que estás siguiendo"
         following_replied: "nueva publicación de alguien que estás siguiendo"
         following: "alguien ha comenzado a seguirte"
       popup:
-        following: "{{username}} ha comenzado a seguirte."
-        following_posted: '{{username}} ha publicado "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} ha publicado en "{{topic}}" - {{site_title}}'
+        following: "%{username} ha comenzado a seguirte."
+        following_posted: '%{username} ha publicado "%{topic}" - %{site_title}'
+        following_replied: '%{username} ha publicado en "%{topic}" - %{site_title}'
     topics:
       none:
         following: "No hay temas de usuarios que estás siguiendo."
@@ -56,11 +56,11 @@ es:
       following:
         label: "Siguiendo"
         none: "Aún no sigues a nadie."
-        none_other: "{{username}} aún no sigue a nadie."
+        none_other: "%{username} aún no sigue a nadie."
       followers:
         label: "Seguidores"
         none: "Aún nadie te sigue."
-        none_other: "Aún nadie sigue a {{username}}."
+        none_other: "Aún nadie sigue a %{username}."
       follow_notifications_options:
         notify_followed_user_when_followed: "Notificar a los usuarios al seguirlos."
         notify_me_when_followed: "Notificarme cuando los usuarios me siguen."

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -5,14 +5,14 @@ he:
         title: "עוקב"
         help: "נושאים עם פוסטים ממשתמשים שאתה במעקב אחריהם"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "התחיל לעקוב אחריך."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       popup:
-        following: "{{username}} התחיל לעקוב אחריך."
-        following_posted: '{{username}} פרסם "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} הגיב ב"{{topic}}" - {{site_title}}'
+        following: "%{username} התחיל לעקוב אחריך."
+        following_posted: '%{username} פרסם "%{topic}" - %{site_title}'
+        following_replied: '%{username} הגיב ב"%{topic}" - %{site_title}'
     topics:
       none:
         following: "אין כרגע נושאים ממשתמשים שאחריהם אתה עוקב."
@@ -25,11 +25,11 @@ he:
       following:
         label: "עוקב אחרי"
         none: "אינך עוקב אחרי אף אחד."
-        none_other: "{{username}} לא עוקב אחרי אף אחד.."
+        none_other: "%{username} לא עוקב אחרי אף אחד.."
       followers:
         label: "עוקבים"
         none: "אף אחד לא עוקב אחריך."
-        none_other: "אף אחד לא עוקב אחרי {{username}}."
+        none_other: "אף אחד לא עוקב אחרי %{username}."
       follow_notifications_options:
         notify_followed_user_when_followed: "הודע למשתמשים כשאני עוקב אחריהם."
         notify_me_when_followed: "הודע לי כשמשתמשים עוקבים אחריי."

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -18,14 +18,14 @@ hu:
         title: "Követett"
         help: "témák a követett felhasználók bejegyzéseivel"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "elkezdett követni téged."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       popup:
-        following: "{{username}} elkezdett követni téged."
-        following_posted: '{{username}} közzétett "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} közzétett "{{topic}}" - {{site_title}}'
+        following: "%{username} elkezdett követni téged."
+        following_posted: '%{username} közzétett "%{topic}" - %{site_title}'
+        following_replied: '%{username} közzétett "%{topic}" - %{site_title}'
     topics:
       none:
         following: "Nincsenek témák az általad követett felhasználóktól."
@@ -52,11 +52,11 @@ hu:
       following:
         label: "Követett"
         none: "Még nem követsz senkit."
-        none_other: "{{username}} még nem követ senkit."
+        none_other: "%{username} még nem követ senkit."
       followers:
         label: "Követő"
         none: "Még senki nem követ téged."
-        none_other: "Még senki nem követi {{username}}."
+        none_other: "Még senki nem követi %{username}."
       follow_notifications_options:
         notify_followed_user_when_followed: "Értesítsd a felhasználókat, ha elkezdem követni őket."
         notify_me_when_followed: "Értesíts amikor elkezdenek követni."

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -5,14 +5,14 @@ it:
         title: "Following"
         help: "argomenti con messaggi dagli utenti che stai seguendo"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "ha iniziato a seguirti."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       popup:
-        following: "{{username}} ha iniziato a seguirti."
-        following_posted: '{{username}} ha pubblicato "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} ha risposto in "{{topic}}" - {{site_title}}'
+        following: "%{username} ha iniziato a seguirti."
+        following_posted: '%{username} ha pubblicato "%{topic}" - %{site_title}'
+        following_replied: '%{username} ha risposto in "%{topic}" - %{site_title}'
     topics:
       none:
         following: "Non ci sono argomenti dagli utenti che stai seguendo."
@@ -25,11 +25,11 @@ it:
       following:
         label: "Following"
         none: "Non stai ancora seguendo nessuno."
-        none_other: "{{username}} non sta ancora seguendo nessuno."
+        none_other: "%{username} non sta ancora seguendo nessuno."
       followers:
         label: "Followers"
         none: "Nessuno ti sta ancora seguendo."
-        none_other: "Nessuno sta ancora seguendo {{username}}."
+        none_other: "Nessuno sta ancora seguendo %{username}."
       follow_notifications_options:
         notify_followed_user_when_followed: "Notifica gli utenti se inizio a seguirli."
         notify_me_when_followed: "Notificami se altri utenti iniziano a seguirmi."

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -5,14 +5,14 @@ pt-BR:
         title: "Seguindo"
         help: "tópicos com postagens de usuários que você está seguindo"
     notifications:
-      following: "<span>{{username}}</span> {{description}}"
+      following: "<span>%{username}</span> %{description}"
       following_description: "começou a seguir você."
-      following_posted: "<span>{{username}}</span> {{description}}"
-      following_replied: "<span>{{username}}</span> {{description}}"
+      following_posted: "<span>%{username}</span> %{description}"
+      following_replied: "<span>%{username}</span> %{description}"
       popup:
-        following: "{{username}} começou a seguir você."
-        following_posted: '{{username}} postou "{{topic}}" - {{site_title}}'
-        following_replied: '{{username}} respondeu "{{topic}}" - {{site_title}}'
+        following: "%{username} começou a seguir você."
+        following_posted: '%{username} postou "%{topic}" - %{site_title}'
+        following_replied: '%{username} respondeu "%{topic}" - %{site_title}'
     topics:
       none:
         following: "Não há tópicos de usuários que você está seguindo."
@@ -25,11 +25,11 @@ pt-BR:
       following:
         label: "Seguindo"
         none: "Você ainda não está seguindo ninguém."
-        none_other: "{{username}} ainda não está seguindo ninguém."
+        none_other: "%{username} ainda não está seguindo ninguém."
       followers:
         label: "Seguidores"
         none: "Ninguém está te seguindo ainda."
-        none_other: "Ninguém está seguindo {{username}} ainda."
+        none_other: "Ninguém está seguindo %{username} ainda."
       follow_notifications_options:
         notify_followed_user_when_followed: "Notificar os usuários quando eu os seguir."
         notify_me_when_followed: "Notificar-me quando usuários me seguirem."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,8 +1,8 @@
 en:
   discourse_push_notifications:
     popup:
-      following_created_topic: '{{username}} created "{{topic}}" - {{site_title}}'
-      following_replied: '{{username}} posted in "{{topic}}" - {{site_title}}'
+      following_created_topic: '%{username} created "%{topic}" - %{site_title}'
+      following_replied: '%{username} posted in "%{topic}" - %{site_title}'
   site_settings:
     discourse_follow_enabled: "Enable follow plugin."
     follow_show_statistics_on_profile: "Show follow statistics on user profiles."


### PR DESCRIPTION
The correct format for variables is `%{variable_name}` and not
`{{variable_name}}`.

Meta topic: https://meta.discourse.org/t/follow-plugin/110579/289?u=osama