### PR TITLE
FIX: stream comes from `args` instead of `this`

### DIFF
--- a/assets/javascripts/discourse/components/follow-post-stream.hbs
+++ b/assets/javascripts/discourse/components/follow-post-stream.hbs
@@ -1,3 +1,3 @@
-{{#each this.stream.content as |post|}}
+{{#each @stream.content as |post|}}
   {{follow-feed-post post=post}}
 {{/each}}


### PR DESCRIPTION
The `follow-post-stream` needs to get the stream from `this.args` instead of `this` directly. This becomes more relevant when we merge: https://github.com/discourse/discourse/pull/30604, which uses a Glimmer component, which makes it more strict and requires the distinction between `this.stream` and `@stream`.

We will also follow-up in a PR after the above core PR is merged to apply the `PostList` component instead of using `follow-feed-post` which uses the `user-stream` component.

No tests, as it's a minor change and our follow-up PR will change this area once again very soon.