### PR TITLE
DEV: Update selector in test for upcoming core changes

### DIFF
--- a/test/javascripts/acceptance/follow-posts-feed-test.js
+++ b/test/javascripts/acceptance/follow-posts-feed-test.js
@@ -158,7 +158,7 @@ acceptance("Discourse Follow - Follow Posts Feed", function (needs) {
 
   test("posts are shown", async (assert) => {
     await visit("/u/eviltrout/follow/feed");
-    const posts = queryAll(".user-stream .user-stream-item");
+    const posts = queryAll(".user-follows-tab .user-stream-item");
     assert.equal(
       posts.length,
       3,
@@ -173,7 +173,7 @@ acceptance("Discourse Follow - Follow Posts Feed", function (needs) {
 
   test("long posts excerpt", async (assert) => {
     await visit("/u/eviltrout/follow/feed");
-    const posts = queryAll(".user-stream .user-stream-item");
+    const posts = queryAll(".user-follows-tab .user-stream-item");
     assert.ok(
       exists(posts[2].querySelector(".expand-item")),
       "long posts are first rendered collapsed"


### PR DESCRIPTION
For some upcoming core changes (https://github.com/discourse/discourse/pull/30604) where we adopt the `PostList` component, we need to update the query selectors in this plugin test. This should work on the existing codebase, but also allow the new core change PRs to pass its tests as well.