### PR TITLE
SECURITY: Follow post excerpts are shown for hidden posts

### DIFF
--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -17,8 +17,11 @@ class UserFollower < ActiveRecord::Base
         .where(action_code: nil)
         .order(created_at: :desc)
 
+    guardian = Guardian.new(current_user)
+
     results = filter_opted_out_users(results)
-    results = Guardian.new(current_user).filter_allowed_categories(results)
+    results = guardian.filter_allowed_categories(results)
+    results = guardian.filter_hidden_posts(results)
     results = results.limit(limit) if limit
     results = results.where("posts.created_at < ?", created_before) if created_before
     results = results.where("posts.created_at > ?", created_after) if created_after

--- a/app/serializers/follow_post_serializer.rb
+++ b/app/serializers/follow_post_serializer.rb
@@ -8,6 +8,10 @@ class FollowPostSerializer < ApplicationSerializer
   has_one :user, serializer: BasicUserSerializer, embed: :object
   has_one :topic, serializer: BasicTopicSerializer, embed: :object
 
+  def post_item_excerpt_post
+    object
+  end
+
   def category_id
     object.topic.category_id
   end

--- a/spec/requests/follow_controller_spec.rb
+++ b/spec/requests/follow_controller_spec.rb
@@ -240,6 +240,24 @@ describe Follow::FollowController do
       expect(response_topic_ids(response)).to eq([post_1, post_2, post_3, post_4, post_5].map(&:id))
     end
 
+    it "omits hidden posts from followed users", :aggregate_failures do
+      hidden_post =
+        Fabricate(
+          :post,
+          user: user2,
+          raw: "private hidden follow post",
+          hidden: true,
+          created_at: 1.hour.ago,
+        )
+
+      sign_in(user1)
+      get "/follow/posts/#{user1.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_topic_ids(response)).to eq([post_1, post_2, post_3, post_4, post_5].map(&:id))
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+
     it "indicates in the response whether or not there are more posts" do
       sign_in(user1)
       get "/follow/posts/#{user1.username}.json", params: { limit: 2 }


### PR DESCRIPTION
## Summary

This fixes a case where a user who is following another user who posts something that later gets hidden still could see the content of that hidden post. 


Hidden posts should only be visible to users in `hidden_post_visible_groups`, staff and the author


## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1228
- Affected file: https://github.com/discourse/discourse-follow/blob/main/app/serializers/follow_post_serializer.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>