### PR TITLE
SECURITY: Follow post excerpts are shown for hidden posts [backport 2026.4]

### DIFF
--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -17,8 +17,11 @@ class UserFollower < ActiveRecord::Base
         .where(action_code: nil)
         .order(created_at: :desc)
 
+    guardian = Guardian.new(current_user)
+
     results = filter_opted_out_users(results)
-    results = Guardian.new(current_user).filter_allowed_categories(results)
+    results = guardian.filter_allowed_categories(results)
+    results = filter_hidden_posts(results, current_user)
     results = results.limit(limit) if limit
     results = results.where("posts.created_at < ?", created_before) if created_before
     results = results.where("posts.created_at > ?", created_after) if created_after
@@ -44,6 +47,17 @@ class UserFollower < ActiveRecord::Base
     results = results.where("topics.created_at > ?", created_after) if created_after
 
     results
+  end
+
+  def self.filter_hidden_posts(relation, current_user)
+    hidden_post_visible_groups = SiteSetting.hidden_post_visible_groups_map
+
+    return relation if hidden_post_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
+    return relation.where("posts.hidden = false") if current_user.blank?
+    return relation if current_user.staff?
+    return relation if current_user.in_any_groups?(hidden_post_visible_groups)
+
+    relation.where("posts.hidden = false OR posts.user_id = ?", current_user.id)
   end
 
   def self.filter_opted_out_users(relation)

--- a/app/serializers/follow_post_serializer.rb
+++ b/app/serializers/follow_post_serializer.rb
@@ -8,6 +8,10 @@ class FollowPostSerializer < ApplicationSerializer
   has_one :user, serializer: BasicUserSerializer, embed: :object
   has_one :topic, serializer: BasicTopicSerializer, embed: :object
 
+  def post_item_excerpt_post
+    object
+  end
+
   def category_id
     object.topic.category_id
   end

--- a/spec/requests/follow_controller_spec.rb
+++ b/spec/requests/follow_controller_spec.rb
@@ -240,6 +240,24 @@ describe Follow::FollowController do
       expect(response_topic_ids(response)).to eq([post_1, post_2, post_3, post_4, post_5].map(&:id))
     end
 
+    it "omits hidden posts from followed users", :aggregate_failures do
+      hidden_post =
+        Fabricate(
+          :post,
+          user: user2,
+          raw: "private hidden follow post",
+          hidden: true,
+          created_at: 1.hour.ago,
+        )
+
+      sign_in(user1)
+      get "/follow/posts/#{user1.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_topic_ids(response)).to eq([post_1, post_2, post_3, post_4, post_5].map(&:id))
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+
     it "indicates in the response whether or not there are more posts" do
       sign_in(user1)
       get "/follow/posts/#{user1.username}.json", params: { limit: 2 }


### PR DESCRIPTION
Backport of #183 to d-compat/2026.4.

---

This release predates `Guardian#filter_hidden_posts` (added in discourse/discourse#40217), so the hidden-post filtering is replicated locally in `UserFollower` using the same visibility rules as this release's `Guardian#can_see_hidden_post?` (everyone-group / staff / `hidden_post_visible_groups` / own posts). The rest of the change is identical to #183.