### PR TITLE
FIX: Honor core profile privacy on follow network pages 

### DIFF
--- a/app/models/follow_pages_visibility.rb
+++ b/app/models/follow_pages_visibility.rb
@@ -41,6 +41,9 @@ class FollowPagesVisibility < EnumSiteSetting
     def can_see_page?(user, target_user, page_setting_value)
       return false if !SiteSetting.discourse_follow_enabled
       return false if target_user.blank?
+      guardian = user&.guardian || Guardian.new
+      return false if !guardian.public_can_see_profiles?
+      return false if !guardian.can_see_profile?(target_user)
       return true if page_setting_value == EVERYONE
       return false if page_setting_value == NO_ONE
       return false if user.blank?

--- a/spec/models/follow_pages_visibility_spec.rb
+++ b/spec/models/follow_pages_visibility_spec.rb
@@ -45,7 +45,10 @@ describe FollowPagesVisibility do
   ].each do |(method, setting)|
     describe ".#{method}" do
       context "when the follow_following_visible site setting allows everyone" do
-        before { SiteSetting.public_send("#{setting}=", FollowPagesVisibility::EVERYONE) }
+        before do
+          SiteSetting.hide_new_user_profiles = false
+          SiteSetting.public_send("#{setting}=", FollowPagesVisibility::EVERYONE)
+        end
 
         it "trust level 0 user is allowed to see the page" do
           expect(described_class.public_send(method, user: tl0, target_user: user)).to eq(true)

--- a/spec/requests/follow_controller_spec.rb
+++ b/spec/requests/follow_controller_spec.rb
@@ -3,6 +3,7 @@
 describe Follow::FollowController do
   fab!(:user1, :user)
   fab!(:user2, :user)
+  fab!(:admin)
   fab!(:tl4) { Fabricate(:user, trust_level: TrustLevel[4]) }
   fab!(:tl3) { Fabricate(:user, trust_level: TrustLevel[3]) }
   fab!(:tl2) { Fabricate(:user, trust_level: TrustLevel[2]) }
@@ -12,6 +13,7 @@ describe Follow::FollowController do
   def expect_not_allowed(user, type)
     get "/u/#{user.username}/follow/#{type}.json"
     expect(response.status).to eq(403)
+    expect(response.parsed_body["errors"]).to be_present
   end
 
   def expect_allowed(user, type)
@@ -55,11 +57,39 @@ describe Follow::FollowController do
 
       context "when follow_#{type}_visible setting is set to everyone" do
         before do
+          SiteSetting.hide_new_user_profiles = false
           SiteSetting.public_send("follow_#{type}_visible=", FollowPagesVisibility::EVERYONE)
         end
 
         it "anon users can see pages of normal users" do
           expect_allowed(user1, type)
+        end
+
+        it "blocks anon users when core hides profiles from the public" do
+          SiteSetting.hide_user_profiles_from_public = true
+          expect_not_allowed(user1, type)
+        end
+
+        context "when the target user has hidden their profile" do
+          before do
+            SiteSetting.allow_users_to_hide_profile = true
+            user1.user_option.update!(hide_profile: true)
+          end
+
+          it "blocks other logged-in users" do
+            sign_in(user2)
+            expect_not_allowed(user1, type)
+          end
+
+          it "still allows the user to see their own page" do
+            sign_in(user1)
+            expect_allowed(user1, type)
+          end
+
+          it "still allows staff" do
+            sign_in(admin)
+            expect_allowed(user1, type)
+          end
         end
       end
 

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -17,6 +17,7 @@ describe UserCardSerializer do
     before do
       SiteSetting.discourse_follow_enabled = true
       SiteSetting.follow_show_statistics_on_profile = true
+      SiteSetting.hide_new_user_profiles = false
       SiteSetting.follow_followers_visible = FollowPagesVisibility::EVERYONE
       SiteSetting.follow_following_visible = FollowPagesVisibility::EVERYONE
     end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -17,6 +17,7 @@ describe UserSerializer do
     before do
       SiteSetting.discourse_follow_enabled = true
       SiteSetting.follow_show_statistics_on_profile = true
+      SiteSetting.hide_new_user_profiles = false
       SiteSetting.follow_followers_visible = FollowPagesVisibility::EVERYONE
       SiteSetting.follow_following_visible = FollowPagesVisibility::EVERYONE
     end


### PR DESCRIPTION
The followers/following pages (and the follower/following counts on user cards and profiles)
were gated only by the plugin's own visibility settings, we should have respected core's settings.