### PR TITLE
SECURITY: Follow feed exposes shared draft topic titles to followers

### DIFF
--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -20,6 +20,12 @@ class UserFollower < ActiveRecord::Base
     guardian = Guardian.new(current_user)
 
     results = filter_opted_out_users(results)
+    if !guardian.can_see_shared_draft?
+      results =
+        results.joins("LEFT OUTER JOIN shared_drafts ON shared_drafts.topic_id = topics.id").where(
+          "shared_drafts.id IS NULL",
+        )
+    end
     results = guardian.filter_allowed_categories(results)
     results = guardian.filter_hidden_posts(results)
     results = results.limit(limit) if limit

--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -20,12 +20,7 @@ class UserFollower < ActiveRecord::Base
     guardian = Guardian.new(current_user)
 
     results = filter_opted_out_users(results)
-    if !guardian.can_see_shared_draft?
-      results =
-        results.joins("LEFT OUTER JOIN shared_drafts ON shared_drafts.topic_id = topics.id").where(
-          "shared_drafts.id IS NULL",
-        )
-    end
+    results = filter_shared_drafts(results, guardian)
     results = guardian.filter_allowed_categories(results)
     results = guardian.filter_hidden_posts(results)
     results = results.limit(limit) if limit
@@ -53,6 +48,12 @@ class UserFollower < ActiveRecord::Base
     results = results.where("topics.created_at > ?", created_after) if created_after
 
     results
+  end
+
+  def self.filter_shared_drafts(relation, guardian)
+    return relation if guardian.can_see_shared_draft?
+
+    relation.where.not(topic_id: SharedDraft.select(:topic_id))
   end
 
   def self.filter_opted_out_users(relation)

--- a/spec/requests/follow_controller_spec.rb
+++ b/spec/requests/follow_controller_spec.rb
@@ -288,6 +288,38 @@ describe Follow::FollowController do
       expect(response.body).not_to include(hidden_post.raw)
     end
 
+    it "omits shared draft posts when the viewer cannot see shared drafts", :aggregate_failures do
+      shared_drafts_category = Fabricate(:category)
+      destination_category = Fabricate(:category)
+      shared_draft_topic =
+        Fabricate(
+          :topic,
+          user: user2,
+          category: shared_drafts_category,
+          title: "Private shared draft follow topic",
+        )
+      Fabricate(:shared_draft, topic: shared_draft_topic, category: destination_category)
+      shared_draft_post =
+        Fabricate(
+          :post,
+          user: user2,
+          topic: shared_draft_topic,
+          raw: "private shared draft follow post",
+          created_at: 1.hour.ago,
+        )
+
+      SiteSetting.shared_drafts_category = shared_drafts_category.id
+      SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:admins]
+
+      sign_in(user1)
+      get "/follow/posts/#{user1.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_topic_ids(response)).to eq([post_1, post_2, post_3, post_4, post_5].map(&:id))
+      expect(response.body).not_to include(shared_draft_topic.title)
+      expect(response.body).not_to include(shared_draft_post.raw)
+    end
+
     it "indicates in the response whether or not there are more posts" do
       sign_in(user1)
       get "/follow/posts/#{user1.username}.json", params: { limit: 2 }


### PR DESCRIPTION
## Summary

Prevent the leakage of shared draft topic titles and post content in the follow feed by correctly filtering out topics with associated shared drafts for unauthorized users. The query now explicitly checks the viewer's shared draft visibility before returning posts from followed users.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1405

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>